### PR TITLE
Fix: Center profile pics

### DIFF
--- a/docs/people/index.html
+++ b/docs/people/index.html
@@ -2,12 +2,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
 
   <meta charset="utf-8">
-  <meta name="generator" content="quarto-1.4.549">
+  <meta name="generator" content="quarto-1.5.52">
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 
-  <title>Monash NUMBATs - Meet the team</title>
+  <title>Meet the team – Monash NUMBATs</title>
   <style>
     code{white-space: pre-wrap;}
     span.smallcaps{font-variant: small-caps;}
@@ -155,7 +155,7 @@
       })
       </script>
   
-    <script>window.backupDefine = window.define; window.define = undefined;</script><script src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.js"></script>
+    <script>window.backupDefine = window.define; window.define = undefined;</script><script src="https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.js"></script>
     <script>document.addEventListener("DOMContentLoaded", function () {
  var mathElements = document.getElementsByClassName("math");
  var macros = [];
@@ -170,9 +170,10 @@
    });
 }}});
     </script>
-    <script>window.define = window.backupDefine; window.backupDefine = undefined;</script><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.css">
+    <script>window.define = window.backupDefine; window.backupDefine = undefined;</script><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css">
   
     <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="styles.css">
   
 <link href="../site_libs/quarto-contrib/fontawesome6-0.1.0/all.css" rel="stylesheet">
 <link href="../site_libs/quarto-contrib/fontawesome6-0.1.0/latex-fontsize.css" rel="stylesheet">
@@ -191,7 +192,7 @@
         </a>
       </div>
                 <div id="quarto-search" class="" title="Search"></div>
-              <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
+              <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" role="menu" aria-expanded="false" aria-label="Toggle navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
       <span class="navbar-toggler-icon"></span>
     </button>
               <div class="collapse navbar-collapse" id="navbarCollapse">
@@ -230,7 +231,7 @@
       </li>  
     </ul>
               </div> <!-- /navcollapse -->
-              <div class="quarto-navbar-tools">
+                <div class="quarto-navbar-tools">
     </div>
           </div> <!-- /container-fluid -->
         </nav>
@@ -274,11 +275,11 @@
   <h2 class="anchored" data-anchor-id="current">Current</h2>
   <div id="listing-current" class="quarto-listing quarto-listing-container-grid">
   <div class="list grid quarto-listing-cols-3">
-  <div class="g-col-1" data-index="0" data-listing-file-modified-sort="1711084686528" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="0" data-listing-file-modified-sort="1722477462934" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/ek-alexander/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/ek-alexander/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/ek-alexander/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -291,11 +292,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="1" data-listing-file-modified-sort="1711352175537" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="1" data-listing-file-modified-sort="1722477462935" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/forbes-catherine/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/forbes-catherine/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/forbes-catherine/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -308,11 +309,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="2" data-listing-file-modified-sort="1677139531706" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="2" data-listing-file-modified-sort="1722477462934" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/cynthia-huang/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/cynthia-huang/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/cynthia-huang/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -325,11 +326,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="3" data-listing-file-modified-sort="1711084686529" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="3" data-listing-file-modified-sort="1722477462974" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/vukcevic-damjan/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/vukcevic-damjan/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/vukcevic-damjan/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -342,11 +343,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="4" data-listing-file-modified-sort="1711352237564" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="4" data-listing-file-modified-sort="1722477462935" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/frazier-david/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/frazier-david/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/frazier-david/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -359,11 +360,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="5" data-listing-file-modified-sort="1711084686530" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="5" data-listing-file-modified-sort="1722477462977" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/wu-david/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/wu-david/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/wu-david/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -376,11 +377,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="6" data-listing-file-modified-sort="1711085517553" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="6" data-listing-file-modified-sort="1722477462932" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/cook-di/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/cook-di/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/cook-di/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -393,11 +394,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="7" data-listing-file-modified-sort="1711352525325" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="7" data-listing-file-modified-sort="1722477462955" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/nibbering-didier/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/nibbering-didier/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/nibbering-didier/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -410,11 +411,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="8" data-listing-file-modified-sort="1717185457871" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="8" data-listing-file-modified-sort="1722477462945" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/lin-dongqi/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/lin-dongqi/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/lin-dongqi/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -427,11 +428,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="9" data-listing-file-modified-sort="1722403445551" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="9" data-listing-file-modified-sort="1722767594623" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/martin-gael/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/martin-gael/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/martin-gael/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -444,11 +445,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="10" data-listing-file-modified-sort="1677139531701" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="10" data-listing-file-modified-sort="1722477462930" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/athansopoulos-george/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/athansopoulos-george/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/athansopoulos-george/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -461,11 +462,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="11" data-listing-file-modified-sort="1677139531725" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="11" data-listing-file-modified-sort="1722477462946" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/mason-harriet/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/mason-harriet/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/mason-harriet/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -478,11 +479,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="12" data-listing-file-modified-sort="1717122177415" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="12" data-listing-file-modified-sort="1722477462940" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/jewson-jack/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/jewson-jack/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/jewson-jack/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -495,11 +496,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="13" data-listing-file-modified-sort="1711084686529" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="13" data-listing-file-modified-sort="1722477462977" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/wanniarachchi-janith/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/wanniarachchi-janith/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/wanniarachchi-janith/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -512,11 +513,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="14" data-listing-file-modified-sort="1711351621128" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="14" data-listing-file-modified-sort="1722477462932" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/chapman-jarryd/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/chapman-jarryd/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/chapman-jarryd/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -529,11 +530,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="15" data-listing-file-modified-sort="1677139531720" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="15" data-listing-file-modified-sort="1722477462943" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/leung-jessica/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/leung-jessica/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/leung-jessica/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -546,11 +547,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="16" data-listing-file-modified-sort="1677139531819" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="16" data-listing-file-modified-sort="1722477462974" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/saunders-kate/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/saunders-kate/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/saunders-kate/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -563,11 +564,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="17" data-listing-file-modified-sort="1677139531699" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="17" data-listing-file-modified-sort="1722477462930" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/ackermann-klaus/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/ackermann-klaus/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/ackermann-klaus/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -580,11 +581,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="18" data-listing-file-modified-sort="1722403428298" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="18" data-listing-file-modified-sort="1722767594623" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/anukarnsakulchularp-krisanat/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/anukarnsakulchularp-krisanat/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/anukarnsakulchularp-krisanat/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -597,11 +598,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="19" data-listing-file-modified-sort="1677139531721" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="19" data-listing-file-modified-sort="1722477462945" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/lydeamore-michael/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/lydeamore-michael/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/lydeamore-michael/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -614,11 +615,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="20" data-listing-file-modified-sort="1711352591980" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="20" data-listing-file-modified-sort="1722477462956" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/ohara-wild-mitch/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/ohara-wild-mitch/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/ohara-wild-mitch/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -631,11 +632,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="21" data-listing-file-modified-sort="1677139531769" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="21" data-listing-file-modified-sort="1722477462956" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/palihawadana-nuwani/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/palihawadana-nuwani/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/palihawadana-nuwani/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -648,11 +649,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="22" data-listing-file-modified-sort="1677139531713" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="22" data-listing-file-modified-sort="1722477462940" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/lakshika-jayani/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/lakshika-jayani/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/lakshika-jayani/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -665,11 +666,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="23" data-listing-file-modified-sort="1677139531720" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="23" data-listing-file-modified-sort="1722477462944" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/li-patrick/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/li-patrick/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/li-patrick/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -682,11 +683,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="24" data-listing-file-modified-sort="1711084686528" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="24" data-listing-file-modified-sort="1722477462939" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/hyndman-rob-j/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/hyndman-rob-j/RJH_square_small.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/hyndman-rob-j/RJH_square_small.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -699,11 +700,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="25" data-listing-file-modified-sort="1711352521397" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="25" data-listing-file-modified-sort="1722477462955" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/maya-ruben-loaiza/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/maya-ruben-loaiza/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/maya-ruben-loaiza/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -716,11 +717,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="26" data-listing-file-modified-sort="1693358600993" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="26" data-listing-file-modified-sort="1722477462936" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/fui-swen-kuh/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/fui-swen-kuh/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/fui-swen-kuh/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -733,11 +734,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="27" data-listing-file-modified-sort="1711085468232" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="27" data-listing-file-modified-sort="1722477462939" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/jafari-tina/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/jafari-tina/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/jafari-tina/avatar.png" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -750,11 +751,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="28" data-listing-file-modified-sort="1711084686529" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="28" data-listing-file-modified-sort="1722477462976" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/wang-xiaoqian/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/wang-xiaoqian/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/wang-xiaoqian/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -767,11 +768,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="29" data-listing-file-modified-sort="1677139531835" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="29" data-listing-file-modified-sort="1722477462978" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/current/yang-yangzhuoran-fin/index.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/current/yang-yangzhuoran-fin/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
+  <img loading="lazy" src="../people/current/yang-yangzhuoran-fin/avatar.jpg" class="thumbnail-image card-img" style="height: 225px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -794,11 +795,11 @@
   <h2 class="anchored" data-anchor-id="visitors">Visitors</h2>
   <div id="listing-visitor" class="quarto-listing quarto-listing-container-grid">
   <div class="list grid quarto-listing-cols-4">
-  <div class="g-col-1" data-index="0" data-listing-file-modified-sort="1717115213095" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="0" data-listing-file-modified-sort="1722477462979" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/visitors/galit.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/visitors/galit.jpeg" class="thumbnail-image card-img" style="height: 150px;">
+  <img loading="lazy" src="../people/visitors/galit.jpeg" class="thumbnail-image card-img" style="height: 150px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -811,11 +812,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="1" data-listing-file-modified-sort="1711084686530" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="1" data-listing-file-modified-sort="1722477462979" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/visitors/paulo.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/visitors/paulo.jpeg" class="thumbnail-image card-img" style="height: 150px;">
+  <img loading="lazy" src="../people/visitors/paulo.jpeg" class="thumbnail-image card-img" style="height: 150px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -828,11 +829,11 @@
   </div>
   </a>
   </div>
-  <div class="g-col-1" data-index="2" data-listing-file-modified-sort="1717114616908" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
+  <div class="g-col-1" data-index="2" data-listing-file-modified-sort="1722477462979" data-listing-reading-time-sort="1" data-listing-word-count-sort="1">
   <a href="../people/visitors/thomas.html" class="quarto-grid-link">
   <div class="quarto-grid-item card h-100 card-left">
   <p class="card-img-top">
-  <img src="../people/visitors/thomas.png" class="thumbnail-image card-img" style="height: 150px;">
+  <img loading="lazy" src="../people/visitors/thomas.png" class="thumbnail-image card-img" style="height: 150px;">
   </p>
   <div class="card-body post-contents">
   <h5 class="no-anchor card-title listing-title">
@@ -874,9 +875,9 @@
   </tr>
   </thead>
   <tbody class="list">
-  <tr data-index="0" data-listing-file-modified-sort="1677139531679" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Anastasios Panagiotelis" data-listing-filename-sort="index.qmd">
+  <tr data-index="0" data-listing-file-modified-sort="1722477462922" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Anastasios Panagiotelis" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/panagiotelis-anastasios/avatar.png" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/panagiotelis-anastasios/avatar.png" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/panagiotelis-anastasios/index.html" class="title listing-title">Anastasios Panagiotelis</a>
@@ -885,9 +886,9 @@
   <span class="listing-description">Associate Professor</span>
   </td>
   </tr>
-  <tr data-index="1" data-listing-file-modified-sort="1677139531680" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Cameron Roach" data-listing-filename-sort="index.qmd">
+  <tr data-index="1" data-listing-file-modified-sort="1722477462922" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Cameron Roach" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/roach-cameron/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/roach-cameron/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/roach-cameron/index.html" class="title listing-title">Cameron Roach</a>
@@ -896,9 +897,9 @@
   <span class="listing-description">PhD (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="2" data-listing-file-modified-sort="1677139531686" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Dan Simpson" data-listing-filename-sort="index.qmd">
+  <tr data-index="2" data-listing-file-modified-sort="1722477462923" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Dan Simpson" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/simpson-dan/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/simpson-dan/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/simpson-dan/index.html" class="title listing-title">Dan Simpson</a>
@@ -907,9 +908,9 @@
   <span class="listing-description">Professor of Analytics Engagement</span>
   </td>
   </tr>
-  <tr data-index="3" data-listing-file-modified-sort="1677139531697" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Earo Wang" data-listing-filename-sort="index.qmd">
+  <tr data-index="3" data-listing-file-modified-sort="1722477462929" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Earo Wang" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/wang-earo/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/wang-earo/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/wang-earo/index.html" class="title listing-title">Earo Wang</a>
@@ -918,9 +919,9 @@
   <span class="listing-description">Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="4" data-listing-file-modified-sort="1711084686527" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Emi Tanaka" data-listing-filename-sort="index.qmd">
+  <tr data-index="4" data-listing-file-modified-sort="1722477462925" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Emi Tanaka" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/tanaka-emi/avatar.png" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/tanaka-emi/avatar.png" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/tanaka-emi/index.html" class="title listing-title">Emi Tanaka</a>
@@ -929,9 +930,9 @@
   <span class="listing-description">Senior Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="5" data-listing-file-modified-sort="1711084686525" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Fan Cheng" data-listing-filename-sort="index.qmd">
+  <tr data-index="5" data-listing-file-modified-sort="1722477462912" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Fan Cheng" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/cheng-fan/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/cheng-fan/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/cheng-fan/index.html" class="title listing-title">Fan Cheng</a>
@@ -940,9 +941,9 @@
   <span class="listing-description">Data Scientist</span>
   </td>
   </tr>
-  <tr data-index="6" data-listing-file-modified-sort="1711084686525" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Lauren Kennedy" data-listing-filename-sort="index.qmd">
+  <tr data-index="6" data-listing-file-modified-sort="1722477462913" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Lauren Kennedy" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/kennedy-lauren/avatar.png" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/kennedy-lauren/avatar.png" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/kennedy-lauren/index.html" class="title listing-title">Lauren Kennedy</a>
@@ -951,9 +952,9 @@
   <span class="listing-description">Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="7" data-listing-file-modified-sort="1677139531697" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Luis Torres" data-listing-filename-sort="index.qmd">
+  <tr data-index="7" data-listing-file-modified-sort="1722477462929" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Luis Torres" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/torres-luis/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/torres-luis/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/torres-luis/index.html" class="title listing-title">Luis Torres</a>
@@ -962,9 +963,9 @@
   <span class="listing-description">Postdoctoral Researcher (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="8" data-listing-file-modified-sort="1677139531671" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Mahdi Abolghasemi" data-listing-filename-sort="index.qmd">
+  <tr data-index="8" data-listing-file-modified-sort="1722477462912" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Mahdi Abolghasemi" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/abolghasemi-mahdi/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/abolghasemi-mahdi/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/abolghasemi-mahdi/index.html" class="title listing-title">Mahdi Abolghasemi</a>
@@ -973,7 +974,7 @@
   <span class="listing-description">Post Doctoral Researcher (Data Science)</span>
   </td>
   </tr>
-  <tr data-index="9" data-listing-file-modified-sort="1677139531697" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Nathaniel Tomasetti" data-listing-filename-sort="index.qmd">
+  <tr data-index="9" data-listing-file-modified-sort="1722477462929" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Nathaniel Tomasetti" data-listing-filename-sort="index.qmd">
   <td>
   <span class="listing-image"><div class="listing-item-img-placeholder card-img-top" style="height: 100px;">&nbsp;</div></span>
   </td>
@@ -984,9 +985,9 @@
   <span class="listing-description">Data Scientist</span>
   </td>
   </tr>
-  <tr data-index="10" data-listing-file-modified-sort="1677139531687" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Nicholas Spyrison" data-listing-filename-sort="index.qmd">
+  <tr data-index="10" data-listing-file-modified-sort="1722477462924" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Nicholas Spyrison" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/spyrison-nicholas/avatar.jpeg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/spyrison-nicholas/avatar.jpeg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/spyrison-nicholas/index.html" class="title listing-title">Nicholas Spyrison</a>
@@ -995,9 +996,9 @@
   <span class="listing-description">PhD (Information Technology)</span>
   </td>
   </tr>
-  <tr data-index="11" data-listing-file-modified-sort="1677139531697" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Nick Tierney" data-listing-filename-sort="index.qmd">
+  <tr data-index="11" data-listing-file-modified-sort="1722477462928" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Nick Tierney" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/tierney-nick/avatar.png" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/tierney-nick/avatar.png" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/tierney-nick/index.html" class="title listing-title">Nick Tierney</a>
@@ -1006,9 +1007,9 @@
   <span class="listing-description">Research Software Engineer</span>
   </td>
   </tr>
-  <tr data-index="12" data-listing-file-modified-sort="1677139531679" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Pablo Montero Manso" data-listing-filename-sort="index.qmd">
+  <tr data-index="12" data-listing-file-modified-sort="1722477462917" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Pablo Montero Manso" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/manso-pablo-montero/avatar.jpeg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/manso-pablo-montero/avatar.jpeg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/manso-pablo-montero/index.html" class="title listing-title">Pablo Montero Manso</a>
@@ -1017,9 +1018,9 @@
   <span class="listing-description">Post Doctoral Researcher (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="13" data-listing-file-modified-sort="1677139531766" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Patricia Menendez" data-listing-filename-sort="index.qmd">
+  <tr data-index="13" data-listing-file-modified-sort="1722477462922" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Patricia Menendez" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/menendez-patricia/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/menendez-patricia/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/menendez-patricia/index.html" class="title listing-title">Patricia Menendez</a>
@@ -1028,9 +1029,9 @@
   <span class="listing-description">Senior Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="14" data-listing-file-modified-sort="1677139531687" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Priyanga Dilini Talagala" data-listing-filename-sort="index.qmd">
+  <tr data-index="14" data-listing-file-modified-sort="1722477462924" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Priyanga Dilini Talagala" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/talagala-priyanga-dilini/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/talagala-priyanga-dilini/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/talagala-priyanga-dilini/index.html" class="title listing-title">Priyanga Dilini Talagala</a>
@@ -1039,9 +1040,9 @@
   <span class="listing-description">Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="15" data-listing-file-modified-sort="1677139531672" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Puwasala Gamakumara" data-listing-filename-sort="index.qmd">
+  <tr data-index="15" data-listing-file-modified-sort="1722477462912" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Puwasala Gamakumara" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/gamakumara-puwasala/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/gamakumara-puwasala/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/gamakumara-puwasala/index.html" class="title listing-title">Puwasala Gamakumara</a>
@@ -1050,9 +1051,9 @@
   <span class="listing-description">Post Doctoral Researcher (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="16" data-listing-file-modified-sort="1677139531695" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Ryan Thompson" data-listing-filename-sort="index.qmd">
+  <tr data-index="16" data-listing-file-modified-sort="1722477462927" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Ryan Thompson" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/thompson-ryan/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/thompson-ryan/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/thompson-ryan/index.html" class="title listing-title">Ryan Thompson</a>
@@ -1061,9 +1062,9 @@
   <span class="listing-description">PhD (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="17" data-listing-file-modified-sort="1677139531673" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Sayani Gupta" data-listing-filename-sort="index.qmd">
+  <tr data-index="17" data-listing-file-modified-sort="1722477462913" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Sayani Gupta" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/gupta-sayani/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/gupta-sayani/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/gupta-sayani/index.html" class="title listing-title">Sayani Gupta</a>
@@ -1072,9 +1073,9 @@
   <span class="listing-description">PhD (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="18" data-listing-file-modified-sort="1677139531673" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Sevvandi Kandanaarachchi" data-listing-filename-sort="index.qmd">
+  <tr data-index="18" data-listing-file-modified-sort="1722477462913" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Sevvandi Kandanaarachchi" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/kandanaarachchi-sevvandi/avatar.jpeg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/kandanaarachchi-sevvandi/avatar.jpeg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/kandanaarachchi-sevvandi/index.html" class="title listing-title">Sevvandi Kandanaarachchi</a>
@@ -1083,9 +1084,9 @@
   <span class="listing-description">Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="19" data-listing-file-modified-sort="1677139531835" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Sherry Zhang" data-listing-filename-sort="index.qmd">
+  <tr data-index="19" data-listing-file-modified-sort="1722477462929" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Sherry Zhang" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/zhang-sherry/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/zhang-sherry/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/zhang-sherry/index.html" class="title listing-title">Sherry Zhang</a>
@@ -1094,9 +1095,9 @@
   <span class="listing-description">PhD (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="20" data-listing-file-modified-sort="1711084686526" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Stephanie Kobakian" data-listing-filename-sort="index.qmd">
+  <tr data-index="20" data-listing-file-modified-sort="1722477462914" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Stephanie Kobakian" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/kobakian-stephanie/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/kobakian-stephanie/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/kobakian-stephanie/index.html" class="title listing-title">Stephanie Kobakian</a>
@@ -1105,9 +1106,9 @@
   <span class="listing-description">Data Scientist</span>
   </td>
   </tr>
-  <tr data-index="21" data-listing-file-modified-sort="1677139531679" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Stuart Lee" data-listing-filename-sort="index.qmd">
+  <tr data-index="21" data-listing-file-modified-sort="1722477462916" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Stuart Lee" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/lee-stuart/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/lee-stuart/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/lee-stuart/index.html" class="title listing-title">Stuart Lee</a>
@@ -1116,9 +1117,9 @@
   <span class="listing-description">Postdoctoral Researcher (Statistics)</span>
   </td>
   </tr>
-  <tr data-index="22" data-listing-file-modified-sort="1677139531687" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Thiyanga Talagala" data-listing-filename-sort="index.qmd">
+  <tr data-index="22" data-listing-file-modified-sort="1722477462925" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Thiyanga Talagala" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/talagala-thiyanga/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/talagala-thiyanga/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/talagala-thiyanga/index.html" class="title listing-title">Thiyanga Talagala</a>
@@ -1127,9 +1128,9 @@
   <span class="listing-description">Lecturer in Statistics</span>
   </td>
   </tr>
-  <tr data-index="23" data-listing-file-modified-sort="1677139531678" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Ursula Laa" data-listing-filename-sort="index.qmd">
+  <tr data-index="23" data-listing-file-modified-sort="1722477462916" data-listing-reading-time-sort="1" data-listing-word-count-sort="1" data-listing-title-sort="Ursula Laa" data-listing-filename-sort="index.qmd">
   <td>
-  <span class="listing-image"><img src="../people/alumni/laa-ursula/avatar.jpg" style="height: 100px;"></span>
+  <span class="listing-image"><img loading="lazy" src="../people/alumni/laa-ursula/avatar.jpg" style="height: 100px;"></span>
   </td>
   <td>
   <a href="../people/alumni/laa-ursula/index.html" class="title listing-title">Ursula Laa</a>
@@ -1185,18 +1186,7 @@
         }
         return false;
       }
-      const clipboard = new window.ClipboardJS('.code-copy-button', {
-        text: function(trigger) {
-          const codeEl = trigger.previousElementSibling.cloneNode(true);
-          for (const childEl of codeEl.children) {
-            if (isCodeAnnotation(childEl)) {
-              childEl.remove();
-            }
-          }
-          return codeEl.innerText;
-        }
-      });
-      clipboard.on('success', function(e) {
+      const onCopySuccess = function(e) {
         // button target
         const button = e.trigger;
         // don't keep focus
@@ -1228,7 +1218,47 @@
         }, 1000);
         // clear code selection
         e.clearSelection();
+      }
+      const getTextToCopy = function(trigger) {
+          const codeEl = trigger.previousElementSibling.cloneNode(true);
+          for (const childEl of codeEl.children) {
+            if (isCodeAnnotation(childEl)) {
+              childEl.remove();
+            }
+          }
+          return codeEl.innerText;
+      }
+      const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+        text: getTextToCopy
       });
+      clipboard.on('success', onCopySuccess);
+      if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+        // For code content inside modals, clipBoardJS needs to be initialized with a container option
+        // TODO: Check when it could be a function (https://github.com/zenorocha/clipboard.js/issues/860)
+        const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+          text: getTextToCopy,
+          container: window.document.getElementById('quarto-embedded-source-code-modal')
+        });
+        clipboardModal.on('success', onCopySuccess);
+      }
+        var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+        var mailtoRegex = new RegExp(/^mailto:/);
+          var filterRegex = new RegExp('/' + window.location.host + '/');
+        var isInternal = (href) => {
+            return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+        }
+        // Inspect non-navigation links and adorn them if external
+     	var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+        for (var i=0; i<links.length; i++) {
+          const link = links[i];
+          if (!isInternal(link.href)) {
+            // undo the damage that might have been done by quarto-nav.js in the case of
+            // links that we want to consider external
+            if (link.dataset.originalHref !== undefined) {
+              link.href = link.dataset.originalHref;
+            }
+          }
+        }
       function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
         const config = {
           allowHTML: true,
@@ -1263,7 +1293,11 @@
           try { href = new URL(href).hash; } catch {}
           const id = href.replace(/^#\/?/, "");
           const note = window.document.getElementById(id);
-          return note.innerHTML;
+          if (note) {
+            return note.innerHTML;
+          } else {
+            return "";
+          }
         });
       }
       const xrefs = window.document.querySelectorAll('a.quarto-xref');

--- a/docs/people/styles.css
+++ b/docs/people/styles.css
@@ -1,0 +1,13 @@
+/* Styles to center and pad images of current people */
+.card-img-top {
+  width: fit-content;
+}
+
+.card {
+  align-items: center;
+  padding: 1rem;
+}
+
+.card:hover {
+  box-shadow: 0 0.01rem 10px rgba(62, 62, 62, 0.2);
+}

--- a/people/index.qmd
+++ b/people/index.qmd
@@ -32,6 +32,7 @@ listing:
       role: ""
 page-layout: full
 comments: false
+css: styles.css
 ---
 
 ## Current

--- a/people/styles.css
+++ b/people/styles.css
@@ -1,0 +1,13 @@
+/* Styles to center and pad images of current people */
+.card-img-top {
+  width: fit-content;
+}
+
+.card {
+  align-items: center;
+  padding: 1rem;
+}
+
+.card:hover {
+  box-shadow: 0 0.01rem 10px rgba(62, 62, 62, 0.2);
+}


### PR DESCRIPTION
Changelog:

* Centers profile images of current and alumni members
* Adds a tiny drop shadow on hover

Note: I have included only the build artefacts necessary for this PR. Since my Quarto version is different, rendering the site creates minor changes to most files, thereby cluttering the PR with hard-to-review changes.