### PR TITLE
Correct the name of ETC3555

### DIFF
--- a/unit_information/BComm_unit_summaries.qmd
+++ b/unit_information/BComm_unit_summaries.qmd
@@ -30,7 +30,7 @@ The following are elective units that can contribute towards the major (first di
 - ETC2410 Introductory econometrics 
 - BEX3726: Engaging with international business
 - ETC3550: Applied forecasting
-- ETC3555: Statistical machine mining
+- ETC3555: Statistical machine learning
 - ETC3580: Advanced statistical modelling
 - ETF3500: High dimensional data analysis
 - FIT1045: Algorithms and programming fundamentals in python

--- a/unit_information/MBAt_unit_summaries.qmd
+++ b/unit_information/MBAt_unit_summaries.qmd
@@ -51,7 +51,7 @@ And **at least two** of the following four units:
 - ETC5580 Advanced statistical modelling
 - ETF5500 High dimensional data analysis
 - ETC5450 Advanced R programming
-- ETC5555 Statistical machine mining
+- ETC5555 Statistical machine learning
 
 And a further **four elective units** from the following list, or others by special request.
 


### PR DESCRIPTION
Updating ETC3555 to the correct name.

Note: this PR only includes a change to the Quarto file, but not yet the rendered PDFs.